### PR TITLE
Bump to 6.7.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,5 @@
 name: Build
 on:
-  schedule:
-    - cron: '0 0 * * 0'
   workflow_dispatch:
 
 jobs:
@@ -35,7 +33,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: pyinstaller/pyinstaller
-          ref: v5.8.0
+          ref: v6.7.0
 
       - name: Build bootloader
         run: |


### PR DESCRIPTION
Unless we want to pin the yt-dlp build workflow to `setuptools<70` forever, we need to bump to pyinstaller v6.7.0

Ref: https://github.com/pyinstaller/pyinstaller/issues/8554

Also removes the cron schedule; we can just run the workflow manually