### PR TITLE
Bump to 6.11.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: pyinstaller/pyinstaller
-          ref: v6.10.0
+          ref: v6.11.1
 
       - name: Build bootloader
         run: |


### PR DESCRIPTION
https://github.com/pyinstaller/pyinstaller/releases/tag/v6.11.1

Relevant bugfix:

> - (Windows) Add a retry loop to onefile temporary directory cleanup as an attempt to mitigate situations when bundled DLLs and python extension modules remain locked by the OS and/or anti-virus program for a short while after the application process exits. ([#8870](https://github.com/pyinstaller/pyinstaller/issues/8870))