### PR TITLE
Adjust to setuptools => hatchling migration in PyInstaller 6.16

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ on:
       ref:
         description: PyInstaller tag/ref
         required: true
-        default: v6.15.0
+        default: v6.16.0
         type: string
       x64:
         description: Build Windows x64 / win_amd64
@@ -149,7 +149,7 @@ jobs:
           PYI_WHEEL_TAG: ${{ matrix.wheel_tag }}
           PYI_PLATFORM: ${{ matrix.platform }}
         run: |
-          python -m pip install build
+          python -m pip install -U build hatchling
           python -m build --no-isolation --wheel --outdir=dist .
 
       - name: Upload artifacts


### PR DESCRIPTION
Build job for PyInstaller 6.16+ fails if we don't install hatchling

https://github.com/yt-dlp/Pyinstaller-Builds/actions/runs/17702500621