### PR TITLE
Bump actions pins

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,6 @@ on:
       ref:
         description: PyInstaller tag/ref
         required: true
-        default: 3f596f66feebe3a7d247248f95f76c071d08b832  # v6.17.0
         type: string
       x64:
         description: Build Windows x64 / win_amd64

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -159,7 +159,7 @@ jobs:
 
     steps:
       - name: Set up MinGW
-        uses: yt-dlp/setup-msys2@4f806de0a5a7294ffabaff804b38a9b435a73bda  # v2.30.0
+        uses: msys2/setup-msys2@4f806de0a5a7294ffabaff804b38a9b435a73bda  # v2.30.0
         with:
           update: true
           msystem: ${{ matrix.sys }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -136,7 +136,7 @@ jobs:
           python -m build --no-isolation --sdist --outdir=dist .
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6.0.0
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
         with:
           name: pyinstaller-${{ inputs.ref }}-sdist
           path: |
@@ -193,7 +193,7 @@ jobs:
           python -m build --no-isolation --wheel --outdir=dist .
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6.0.0
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
         with:
           name: pyinstaller-${{ inputs.ref }}-${{ matrix.name }}
           path: |
@@ -216,7 +216,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131  # v7.0.0
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           path: artifact
           pattern: pyinstaller-${{ inputs.ref }}-*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,8 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
-  ACTIONLINT_VERSION: "1.7.9"
-  ACTIONLINT_SHA256SUM: 233b280d05e100837f4af1433c7b40a5dcb306e3aa68fb4f17f8a7f45a7df7b4
+  ACTIONLINT_VERSION: "1.7.11"
+  ACTIONLINT_SHA256SUM: 900919a84f2229bac68ca9cd4103ea297abc35e9689ebb842c6e34a3d1b01b0a
   ACTIONLINT_REPO: https://github.com/rhysd/actionlint
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,4 +65,4 @@ jobs:
         with:
           advanced-security: false
           persona: pedantic
-          version: v1.22.0
+          version: v1.23.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Run zizmor
-        uses: zizmorcore/zizmor-action@135698455da5c3b3e55f73f4419e481ab68cdd95  # v0.4.1
+        uses: zizmorcore/zizmor-action@71321a20a9ded102f6e9ce5718a2fcec2c4f70d8  # v0.5.2
         with:
           advanced-security: false
           persona: pedantic


### PR DESCRIPTION
### Updated 3 actions in 2 workflows:

* **`actions/download-artifact`**: **v7.0.0** **→** [**v8.0.1**](https://github.com/actions/download-artifact/releases/tag/v8.0.1) *compare:* [`37930b1c...3e5f45b2`](https://github.com/actions/download-artifact/compare/37930b1c2abaa49bbe596cd826c3c89aef350131...3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c)
* **`actions/upload-artifact`**: **v6.0.0** **→** [**v7.0.0**](https://github.com/actions/upload-artifact/releases/tag/v7.0.0) *compare:* [`b7c566a7...bbbca2dd`](https://github.com/actions/upload-artifact/compare/b7c566a772e6b6bfb58ed0dc250532a479d7789f...bbbca2ddaa5d8feaa63e36b76fdaad77386f024f)
* **`zizmorcore/zizmor-action`**: **v0.4.1** **→** [**v0.5.2**](https://github.com/zizmorcore/zizmor-action/releases/tag/v0.5.2) *compare:* [`13569845...71321a20`](https://github.com/zizmorcore/zizmor-action/compare/135698455da5c3b3e55f73f4419e481ab68cdd95...71321a20a9ded102f6e9ce5718a2fcec2c4f70d8)

### Also:
* Updated `actionlint` from `v1.7.9` to [`v1.7.11`](https://github.com/rhysd/actionlint/releases/tag/v1.7.11)
* Updated `zizmor` from `v1.22.0` to [`v1.23.1`](https://github.com/zizmorcore/zizmor/releases/tag/v1.23.1)
* Moved back to upstream `msys2/setup-msys2`
* Removed default `ref` input value from the build workflow